### PR TITLE
changes to include SaSS Source maps in DEV build

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
   "scripts": {
     "sass:tokens": "npx json-to-scss src/_data/tokens.json src/scss/_tokens.scss",
     "sass:process": "npm run sass:tokens && sass src/scss/global.scss src/_includes/assets/css/global.css --style=compressed",
+    "sass:processDEV": "npm run sass:tokens && sass src/scss/global.scss src/_includes/assets/css/global.css --source-map-urls=absolute --embed-source-map",
     "cms:precompile": "make-dir dist/admin && nunjucks-precompile src/_includes > dist/admin/templates.js -i \"\\.(njk|css|svg)$\"",
     "cms:bundle": "rollup --config",
-    "start": "concurrently \"npm run sass:process -- --watch\" \"npm run cms:bundle -- --watch\" \"chokidar \\\"src/_includes/**\\\" -c \\\"npm run cms:precompile\\\"\" \"npm run serve\"",
+    "start": "concurrently \"npm run sass:processDEV -- --watch\" \"npm run cms:bundle -- --watch\" \"chokidar \\\"src/_includes/**\\\" -c \\\"npm run cms:precompile\\\"\" \"npm run serve\"",
     "serve": "cross-env ELEVENTY_ENV=development npx eleventy --serve",
     "production": "npm run sass:process && npm run cms:precompile && npm run cms:bundle && npx eleventy"
   },

--- a/src/transforms/html-min-transform.js
+++ b/src/transforms/html-min-transform.js
@@ -6,7 +6,7 @@ module.exports = function htmlMinTransform(value, outputPath) {
       useShortDoctype: true,
       removeComments: true,
       collapseWhitespace: true,
-      minifyCSS: true
+      minifyCSS: false
     });
     return minified;
   }


### PR DESCRIPTION
Have got this working really well in Chrome/Edge. The settings 
--source-map-urls=absolute > Points to the actual file, and Chrome will take you to the file from the inspector. The Firefox 
--embed-source-map > this just makes it all part of the index.HTML file

minifyCSS: false is required to make this work, otherwise all the comments are deleted.
This setting has minimal impact on product build. (239 bytes vs 238 with it set to true). This is because sass is doing the compression with --style=compressed,

The difference is due to minifyCSS removing /*# sourceMappingURL=global.css.map */, while --style=compressed does not.

The experience in Chrome is really good from my perspective. Thoughts?






