### PR TITLE
Use UTC to determine livePosts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
   config.addPassthroughCopy('node_modules/nunjucks/browser/nunjucks-slim.js');
   config.addPassthroughCopy('src/robots.txt');
 
-  const now = new Date();
+  const now = new Date(new Date().toUTCString());
 
   // Custom collections
   const livePosts = post => post.date <= now && !post.data.draft;


### PR DESCRIPTION
I experienced an issue with posts not showing when defining a time with the date frontmatter. For example, I expected a post with the date property `2020-05-04T09:15:00` to be visible, but it wasn't. This is due to the timezone differences. I have fixed this by using UTC, but this could be configured.