### PR TITLE
Pre-cache correct font file

### DIFF
--- a/src/_includes/partials/global/service-worker.js
+++ b/src/_includes/partials/global/service-worker.js
@@ -14,7 +14,7 @@ const EXCLUDED_URLS = [
 ];
 
 // URLS that we want to be cached when the worker is installed
-const PRE_CACHE_URLS = ['/', '/fonts/lora-v13-latin-700.woff2'];
+const PRE_CACHE_URLS = ['/', '/fonts/lora-v13-latin-700.woff'];
 
 // You might want to bypass a certain host
 const IGNORED_HOSTS = ['localhost', 'unpkg.com', ];


### PR DESCRIPTION
The font file referenced for pre caching was removed in https://github.com/hankchizljaw/hylia/commit/7e20911ccc44862eea7e326b92c3c3e2cddf13e9.

This missing font file now results in an error for the service worker on first load and reduces lighthouse score because of that error.