### PR TITLE
Remove `defer` attribute from theme-toggle script

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -19,7 +19,7 @@
   {% include "partials/global/site-foot.njk" %}
   {% block foot %}
   {% endblock %}
-  <script type="module" src="/js/components/theme-toggle.js" async defer></script>
+  <script type="module" src="/js/components/theme-toggle.js" async></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {


### PR DESCRIPTION
Hello!

Just a small one: [module scripts defer by default](https://jakearchibald.com/2017/es-modules-in-browsers/#defer-by-default), so I figured I'd remove the extra attribute.