### PR TITLE
Fix code block colouring

### DIFF
--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -115,6 +115,7 @@
     pre > code {
       display: block;
       background: var(--color-dark);
+      color: var(--color-light);
       padding: get-size(700);
       font-size: get-size(500);
     }


### PR DESCRIPTION
By default, `pre > code` has a dark background but the text is still blue. This makes sure that if no syntax highlighting it used the code is still readable 